### PR TITLE
Fix localStorage parsing crash

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,7 +37,12 @@ const App: React.FC = () => {
   useEffect(() => {
     const stored = localStorage.getItem(LOCAL_STORAGE_KEY);
     if (stored) {
-      setLogs(JSON.parse(stored));
+      try {
+        setLogs(JSON.parse(stored));
+      } catch {
+        console.error("Failed to parse emotion logs from localStorage.");
+        localStorage.removeItem(LOCAL_STORAGE_KEY);
+      }
     }
   }, []);
 


### PR DESCRIPTION
## Summary
- handle invalid JSON when loading logs from localStorage

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'babel__core' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6842f4265850832d8682b58653e91dba